### PR TITLE
Add dumping of queries

### DIFF
--- a/src/slplugin.ml
+++ b/src/slplugin.ml
@@ -1,3 +1,5 @@
+open Slplugin_options
+
 open Dataflow2
 open Astral
 open Cil_types
@@ -7,11 +9,6 @@ type t2 = SSL.t list
 let results = ref (Hashtbl.create 1024)
 let solver = Solver.init ()
 
-module Self = Plugin.Register (struct
-  let name = "Shape analysis"
-  let shortname = "SLplugin"
-  let help = ""
-end)
 
 let fail message = Self.fatal ~current:true message
 

--- a/src/slplugin_options.ml
+++ b/src/slplugin_options.ml
@@ -1,0 +1,5 @@
+module Self = Plugin.Register (struct
+  let name = "Shape analysis"
+  let shortname = "SLplugin"
+  let help = ""
+end)

--- a/src/slplugin_options.ml
+++ b/src/slplugin_options.ml
@@ -3,3 +3,8 @@ module Self = Plugin.Register (struct
   let shortname = "SLplugin"
   let help = ""
 end)
+
+module Dump_queries = Self.False (struct
+  let option_name = "-sl-dump-queries"
+  let help = "Dump Astral queries to 'astral_queries' directory."
+end)


### PR DESCRIPTION
This PR adds an option to dump all SL queries. It should work with the newest version of Astral.